### PR TITLE
Svenmd full run

### DIFF
--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -7,6 +7,8 @@ from emannotationschemas.base import NumericField
 import marshmallow as mm
 Base = declarative_base()
 
+annotation_models = {}
+
 
 class InvalidSchemaField(Exception):
     '''Exception raised if a schema can't be translated to a model'''
@@ -68,6 +70,11 @@ def add_column(attrd, k, field):
 
 
 def make_annotation_model_from_schema(dataset, annotation_type, Schema):
+    model_name = dataset.capitalize() + annotation_type.capitalize()
+
+    if model_name in annotation_models:
+        return annotation_models[model_name]
+
     attrd = {
         '__tablename__': dataset + '_' + annotation_type,
         '__mapper_args__': {'polymorphic_identity': dataset, 'concrete': True}
@@ -76,10 +83,9 @@ def make_annotation_model_from_schema(dataset, annotation_type, Schema):
         if (not field.metadata.get('drop_column', False)):
             attrd = add_column(attrd, k, field)
 
-    model_name = dataset.capitalize() + annotation_type.capitalize()
-    return type(model_name,
-                (TSBase,),
-                attrd)
+    annotation_models[model_name] = type(model_name, (TSBase,), attrd)
+
+    return annotation_models[model_name]
 
 
 def make_annotation_model(dataset, annotation_type):

--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -70,11 +70,6 @@ def add_column(attrd, k, field):
 
 
 def make_annotation_model_from_schema(dataset, annotation_type, Schema):
-    model_name = dataset.capitalize() + annotation_type.capitalize()
-
-    if model_name in annotation_models:
-        return annotation_models[model_name]
-
     attrd = {
         '__tablename__': dataset + '_' + annotation_type,
         '__mapper_args__': {'polymorphic_identity': dataset, 'concrete': True}
@@ -83,9 +78,10 @@ def make_annotation_model_from_schema(dataset, annotation_type, Schema):
         if (not field.metadata.get('drop_column', False)):
             attrd = add_column(attrd, k, field)
 
-    annotation_models[model_name] = type(model_name, (TSBase,), attrd)
-
-    return annotation_models[model_name]
+    model_name = dataset.capitalize() + annotation_type.capitalize()
+    return type(model_name,
+                (TSBase,),
+                attrd)
 
 
 def make_annotation_model(dataset, annotation_type):

--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -70,18 +70,20 @@ def add_column(attrd, k, field):
 
 
 def make_annotation_model_from_schema(dataset, annotation_type, Schema):
-    attrd = {
-        '__tablename__': dataset + '_' + annotation_type,
-        '__mapper_args__': {'polymorphic_identity': dataset, 'concrete': True}
-    }
-    for k, field in Schema._declared_fields.items():
-        if (not field.metadata.get('drop_column', False)):
-            attrd = add_column(attrd, k, field)
-
     model_name = dataset.capitalize() + annotation_type.capitalize()
-    return type(model_name,
-                (TSBase,),
-                attrd)
+
+    if model_name not in annotation_models:
+        attrd = {
+            '__tablename__': dataset + '_' + annotation_type,
+            '__mapper_args__': {'polymorphic_identity': dataset, 'concrete': True}
+        }
+        for k, field in Schema._declared_fields.items():
+            if (not field.metadata.get('drop_column', False)):
+                attrd = add_column(attrd, k, field)
+
+        annotation_models[model_name] = type(model_name, (TSBase,), attrd)
+
+    return annotation_models[model_name]
 
 
 def make_annotation_model(dataset, annotation_type):

--- a/emannotationschemas/utils.py
+++ b/emannotationschemas/utils.py
@@ -1,0 +1,20 @@
+import marshmallow as mm
+
+from emannotationschemas.base import BoundSpatialPoint
+
+def get_flattened_bsp_keys_from_schema(schema):
+    """ Returns the flattened keys of BoundSpatialPoints in a schema
+
+    :param schema: schema
+    :return: list
+    """
+    keys = []
+
+    for key in schema.declared_fields.keys():
+        field = schema.declared_fields[key]
+
+        if isinstance(field, mm.fields.Nested) and \
+                isinstance(field.schema, BoundSpatialPoint):
+            keys.append("{}.{}".format(key, "position"))
+
+    return keys


### PR DESCRIPTION
Adding the annotation model cache was necessary to allow multiple calls of `make_annotation_model`. 
Added an extraction of flattened bsps to the new `emannotationschemas/utils.py`.